### PR TITLE
Fixed typos in test names

### DIFF
--- a/tests/evaluate.test.js
+++ b/tests/evaluate.test.js
@@ -56,7 +56,7 @@ describe(evaluate, () => {
     expect(evaluate(ast)).toBe(Math.PI);
   });
 
-  it.skip('should be able to highest number in a range', () => {
+  it.skip('should be able to determine the highest number in a range', () => {
     const ast = {
       type: 'CallExpression',
       name: 'max',

--- a/tests/parse.test.js
+++ b/tests/parse.test.js
@@ -18,7 +18,7 @@ describe(parse, () => {
     expect(parse(tokens)).toEqual(ast);
   });
 
-  it.skip('should return a token with the type of NumericLiteral for number tokens', () => {
+  it.skip('should return a token with the type of Identifier for name tokens', () => {
     const tokens = [{ type: 'Name', value: 'x' }];
 
     const ast = { type: 'Identifier', name: 'x' };


### PR DESCRIPTION
Just found a few typos in some test names that I fixed up.